### PR TITLE
Making SimpleStorageManager work

### DIFF
--- a/deeplens/header.py
+++ b/deeplens/header.py
@@ -10,25 +10,25 @@ from datetime import datetime
 from deeplens.error import HeaderError
 
 def _check_keys(header, keys):
-    '''
-    Check that keys are in header
-    '''
-    return all(key in header for key in keys)
+	'''
+	Check that keys are in header
+	'''
+	return all(key in header for key in keys)
 
 #abstract header class
 class HeaderFunct(object):
 	'''
 	Just a placeholder for error checking
 	'''
-    def __init__(self, header):
-        self.header = header
-        self.keys = []
+	def __init__(self, header):
+		self.header = header
+		self.keys = []
 
 	def update(self, frame):
 		raise NotImplemented("All headers must implement an update call")
 
-    def reset(self):
-        raise NotImplemented("All headers must implement a reset call")
+	def reset(self):
+		raise NotImplemented("All headers must implement a reset call")
 
 class TimeHeader(HeaderFunct):
 	"""TimeHeader represents the most basic header type
@@ -36,11 +36,11 @@ class TimeHeader(HeaderFunct):
 	"""
 
 	def __init__(self, header, forced_new = False, offset=0):
-        super().__init__(header, reselt)
-        self.keys.extend(['start', 'offset', 'end'])
-        if forced_new or not _check_keys(self.header, self.keys):
-            self.header['start'] = offset
-            self.header['end'] = -1
+		super().__init__(header, reselt)
+		self.keys.extend(['start', 'offset', 'end'])
+		if forced_new or not _check_keys(self.header, self.keys):
+			self.header['start'] = offset
+			self.header['end'] = -1
 
 	#keeps track of the start and the end time of the clips
 	def update(self, frame):
@@ -56,16 +56,16 @@ class StorageHeader(HeaderFunct):
 	"""
 
 	def __init__(self, header, forced_new = False, keep_history = True):
-        super().__init__(header, new)
-        self.keys.extend(['last_accessed', 'frequency', 'frequency_start', 'keep_history',\
-                         'access_list', 'access_start'])
-        if new or not _check_keys(self.header, self.keys):
-            self.header['last_accessed'] = 0
-            self.header['frequency'] = 0 
-            self.header['frequency_start'] = datetime.now()
-            self.header['keep_history'] = keep_history
-            self.header['access_list'] = [] # history of access pattern
-            self.header['access_start'] = datetime.now()
+		super().__init__(header, new)
+		self.keys.extend(['last_accessed', 'frequency', 'frequency_start', 'keep_history',\
+						 'access_list', 'access_start'])
+		if new or not _check_keys(self.header, self.keys):
+			self.header['last_accessed'] = 0
+			self.header['frequency'] = 0 
+			self.header['frequency_start'] = datetime.now()
+			self.header['keep_history'] = keep_history
+			self.header['access_list'] = [] # history of access pattern
+			self.header['access_start'] = datetime.now()
 
 	#keeps track of the start and the end time of the clips
 	def update(self):
@@ -83,9 +83,9 @@ class StorageHeader(HeaderFunct):
 		return self.header['keep_history']
 
 	def reset_hist(self):
-		if self.['keep_history']:
-			self.['access_list'] = []
-			self.['access_start'] = datetime.now()
+		if self.header['keep_history']:
+			self.header['access_list'] = []
+			self.header['access_start'] = datetime.now()
 		else:
 			raise HeaderError('history not stored in this header')
 
@@ -96,18 +96,18 @@ class StorageHeader(HeaderFunct):
 			self.reset_hist()
 
 
-class LabelHeader(Header):
+class LabelHeader(HeaderFunct):
 	"""ObjectHeader keeps track of the labels over a video
 	segment and clip ids if they are in another clip are needed
 	"""
 
 	def __init__(self, header, forced_new = False, store_bounding_boxes=True):
-        super().__init__(header, new)
-        self.keys.extend(['bound_boxes', 'store_bound_boxes'])
-        if new or not _check_keys(self.header):
-		    self.header['label_set'] = set()
-		    self.header['bounding_boxes'] = []
-		    self.header['store_bounding_boxes'] = store_bounding_boxes
+		super().__init__(header, new)
+		self.keys.extend(['bound_boxes', 'store_bound_boxes'])
+		if new or not _check_keys(self.header):
+			self.header['label_set'] = set()
+			self.header['bounding_boxes'] = []
+			self.header['store_bounding_boxes'] = store_bounding_boxes
 
 	#handle the update
 	def update(self, frame, bb):
@@ -127,6 +127,6 @@ class LabelHeader(Header):
 		self.header['bounding_boxes'] = []
 		super().reset()
 
-class BoxHeader(Header):
+class BoxHeader(HeaderFunct):
 	"""ObjectHeader keeps track of bounding boxes over frames
 	"""

--- a/deeplens/simple_manager/manager.py
+++ b/deeplens/simple_manager/manager.py
@@ -11,7 +11,7 @@ from deeplens.constants import *
 from deeplens.struct import *
 from deeplens.simple_manager.videoio import *
 from deeplens.simple_manager.file import *
-from deeplens.header import *
+from deeplens.deprecated_header import *
 from deeplens.dataflow.map import *
 from deeplens.error import *
 

--- a/deeplens/simple_manager/videoio.py
+++ b/deeplens/simple_manager/videoio.py
@@ -9,7 +9,7 @@ primitives to encode and decode archived and regular video formats.
 from deeplens.simple_manager.file import *
 from deeplens.constants import *
 from deeplens.struct import *
-from deeplens.header import ObjectHeader
+from deeplens.deprecated_header import ObjectHeader
 from deeplens.utils.clip import *
 
 import cv2
@@ -281,4 +281,4 @@ def read_if(output, condition, clip_size=5, scratch = DEFAULT_TEMP):
 	#sort the list
 	relevant_clips = sorted(list(relevant_clips))
 
-	return [materialize_clip(clips[i], boundaries, streams, condition.sampling) for i in relevant_clips]
+	return [materialize_clip(clips[i], boundaries, streams) for i in relevant_clips]

--- a/deeplens/struct.py
+++ b/deeplens/struct.py
@@ -295,8 +295,8 @@ class Box():
 	
 	def union_box(self, other):
 		return Box(min(self.x0, other.x0), \
-				min(self.y0, other.y0) \
-				max(self.x1, other.x1) \
+				min(self.y0, other.y0), \
+				max(self.x1, other.x1), \
 				max(self.y1, other.y1))
 	"""The storage manager needs a tuple representation of the box, this serializes it.
 	"""

--- a/deeplens/utils/clip.py
+++ b/deeplens/utils/clip.py
@@ -58,9 +58,9 @@ def materialize_clip(clip, boundaries, streams):
 
 	for crop in execution_plan:
 		index, bounds = crop
-		start = streams[index][1]
+		start = 0# streams[index][1]
 		bounds2 = (bounds[0] - start, bounds[1] - start)
-		subiterators.append(streams[index][0][Cut(*bounds2)])
+		subiterators.append(streams[index][Cut(*bounds2)])
 
 	#v = VideoTransform()
 	return itertools.chain(*subiterators)

--- a/deeplens/utils/utils.py
+++ b/deeplens/utils/utils.py
@@ -19,7 +19,7 @@ def play(vstream):
 
 #shows a single frame
 def show(frame):
-	cv2.imshow('Debug',frame)
+	cv2.imshow('Debug',frame['data'])
 	cv2.waitKey(0)
 
 #overlays a bounding box with labels over a frame


### PR DESCRIPTION
I went through and fixed some problems that I ran into while trying to run this:

```python
from deeplens.struct import *
from deeplens.utils import *
from deeplens.dataflow.map import *
from deeplens.simple_manager.manager import *
from deeplens.utils.testing_utils import *

class TestFilter(object):
    def filter(self, header_data):
        return True

manager = SimpleStorageManager(TestTagger(), 'test_store')
manager.put('test.mp4', 'test')
res = manager.get('test', TestFilter(), 100)
play(res[0])
```

While I got this to run, it still plays a black and white version of the video. I'm not sure if this is expected behavior.

`header.py` had an issue with spaces being mixed in with tabs for indentation.

I then found that Simple Manager still needs `deprecated-header.py` to work, so it should be switched back to using `header.py` in the future.

In `clip.py`, my changes were necessary because in the code `streams[index][1]`, `1` is not a transformation that can be applied to videos. I'm not sure how this was originally supposed to work.