### PR TITLE
SimpleManager get improvements, fixed typos

### DIFF
--- a/deeplens/full_manager/full_manager.py
+++ b/deeplens/full_manager/full_manager.py
@@ -82,14 +82,14 @@ class FullStorageManager(StorageManager):
                                            other text,
                                            PRIMARY KEY (clip_id, video_name)
                                        );
-           """
-           sql_create_label_table = """CREATE TABLE IF NOT EXISTS label (
+            """
+            sql_create_label_table = """CREATE TABLE IF NOT EXISTS label (
                                            label text NOT NULL,
                                            clip_id integer NOT NULL,
                                            video_name text NOT NULL,
                                            PRIMARY KEY (label. clip_id, video_name)
                                        );
-           """
+            """
             self.cursor.execute(sql_create_label_table)
             self.cursor.execute(sql_create_background_table)
             self.cursor.execute(sql_create_clip_table)
@@ -100,9 +100,6 @@ class FullStorageManager(StorageManager):
         """put adds a video to the storage manager from a file. It should either add
             the video to disk, or a reference in disk to deep storage.
         """
-        except sqlite3.Error as e:
-            print(e)
-
         #delete_video_if_exists(physical_clip) TODO: Update function
         if in_extern_storage: 
             physical_dir = self.externdir

--- a/deeplens/simple_manager/manager.py
+++ b/deeplens/simple_manager/manager.py
@@ -120,15 +120,18 @@ class SimpleStorageManager(StorageManager):
 
 
 	def doGet(self, name, condition, clip_size):
-		"""retrievies a clip of a certain size satisfying the condition
+		"""retrieves a clip of a certain size satisfying the condition
 		"""
-		if name not in self.videos:
-			raise VideoNotFound(name + " not found in " + str(self.videos))
-
-
 		physical_clip = os.path.join(self.basedir, name)
 
-		return read_if(physical_clip, condition, clip_size)
-	
+		try:
+			return read_if(physical_clip, condition, clip_size)
+		# If a file is not found, it indicates that the clip is not in the storage
+		# manager. We should move along and raise a VideoNotFound error so that the user
+		# gets a more descriptive error
+		except FileNotFoundError:
+			pass
+		except:
+			raise
 
-
+		raise VideoNotFound(name + " not found in storage manager")

--- a/deeplens/struct.py
+++ b/deeplens/struct.py
@@ -36,7 +36,7 @@ class VideoStream():
 		self.src = src
 		self.limit = limit
 		self.origin = origin
-		self.propId = None
+		self.propIds = None
 		self.cap = None
 
 	def __getitem__(self, xform):
@@ -78,7 +78,7 @@ class VideoStream():
 		   		self.frame_count += 1
 		   		return {'data': frame, \
 		   				'frame': (self.frame_count - 1),\
-		   				'origin': self. f}
+		   				'origin': self.origin}
 
 		   	else:
 		   		raise StopIteration("Iterator is closed")

--- a/deeplens/tiered_manager/tiered_file.py
+++ b/deeplens/tiered_manager/tiered_file.py
@@ -13,7 +13,6 @@ import os
 import tarfile
 import random
 import cv2
-from deeplens.filesystem.file import *
 
 #import all of the constants
 from deeplens.constants import *

--- a/deeplens/tiered_manager/tiered_manager.py
+++ b/deeplens/tiered_manager/tiered_manager.py
@@ -10,10 +10,9 @@ movement and access.
 
 
 #TODO: Note, we ignored multi-threading for now
-from deeplens.full_manager.tiered import *
-from deeplens.simple_manager.videoio import *
-from deeplens.full_manager.tiered_videoio import *
-from deeplens.full_manager.tiered_file import *
+from deeplens.tiered_manager.tiered import *
+from deeplens.tiered_manager.tiered_videoio import *
+from deeplens.tiered_manager.tiered_file import *
 
 from deeplens.constants import *
 from deeplens.struct import *

--- a/deeplens/tiered_manager/tiered_videoio.py
+++ b/deeplens/tiered_manager/tiered_videoio.py
@@ -7,7 +7,7 @@ primitives to encode and decode archived and regular video formats for a tiered
 storage system.
 """
 
-from deeplens.full_manager.tiered_file import *
+from deeplens.tiered_manager.tiered_file import *
 from deeplens.constants import *
 from deeplens.struct import *
 from deeplens.header import *
@@ -58,7 +58,7 @@ def write_video_auto(vstream, \
 
     global_time_header = {}
     header = {}
-    update_global_header = ObjectHeader(global_time_header,\ 
+    update_global_header = ObjectHeader(global_time_header,\
                                         store_bounding_boxes=False, offset=header_info['offset'])
     
     out_vids = []


### PR DESCRIPTION
There were some typos in `struct.py` that I fixed.

I also started making some fixes in `full_manager` and `tiered_manager`.

The problem in the `doGet` of the managers is that they raise an error if the requested video is not in their `self.videos` set. Videos are only added to this set when the `put` method is called. This means that even if the 'test' video is present on disc, there will still be an error when you try to get it, since it was `put` into the manager before this program was run:
```python
manager.get('test', TestFilter(), 100)
```
So, we should either update the `self.videos` set when the manager is created, or we should just not rely on it to tell us which videos are present.