### PR TITLE
Allow for overwriting of headers with manager.put in sqlite

### DIFF
--- a/deeplens/full_manager/full_videoio.py
+++ b/deeplens/full_manager/full_videoio.py
@@ -342,19 +342,19 @@ def move_one_file(conn, clip_id, video_name, dest_ref):
 
 def insert_clip_header(conn, clip_id, video_name, start_time, end_time, origin_x, origin_y, height, width, video_ref='', is_background = False, translation = 'NULL', other = 'NULL'):
     c = conn.cursor()
-    c.execute("INSERT INTO clip VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    c.execute("INSERT OR REPLACE INTO clip VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                (clip_id, video_name, start_time, end_time, origin_x, origin_y, height, width, video_ref, is_background, translation, other))
     conn.commit()
 
 
 def insert_background_header(conn, background_id, clip_id, video_name):
     c = conn.cursor()
-    c.execute("INSERT INTO background VALUES (?, ?, ?)", (background_id, clip_id, video_name))
+    c.execute("INSERT OR REPLACE INTO background VALUES (?, ?, ?)", (background_id, clip_id, video_name))
     conn.commit()
 
 def insert_label_header(conn, label, clip_id, video_name):
     c = conn.cursor()
-    c.execute("INSERT INTO label VALUES (?, ?, ?)", (label, clip_id, video_name))
+    c.execute("INSERT OR REPLACE INTO label VALUES (?, ?, ?)", (label, clip_id, video_name))
     conn.commit()
 
 def delete_label_header(conn, video_name, label = None, clip_id = None):


### PR DESCRIPTION
I'm not sure if manager.put is intended to be able to overwrite an existing object in the manager of the specified name. If so, then the headers need to sometimes be replaced if they already exist in the database (changes made here). If not, then there should be a check for existence of an object of that name in the database, followed by some error early on if there is.