### PR TITLE
allow new sqlite connections on full manger function calls

### DIFF
--- a/deeplens/full_manager/full_videoio.py
+++ b/deeplens/full_manager/full_videoio.py
@@ -318,7 +318,7 @@ def write_video_single(conn, \
     # conn.close()  # don't close the database before we finish get()!
     return vid_files
     
-def write_video_parrallel(db_path, \
+def write_video_parallel(db_path, \
                         video_file, \
                         target,
                         dir, \

--- a/deeplens/utils/parallel_log_reduce.py
+++ b/deeplens/utils/parallel_log_reduce.py
@@ -2,13 +2,13 @@
 is copyrighted by the University of Chicago. This project is developed by
 the database group (chidata).
 
-paralleL_log_reduce.py calculates approximate intermidiate times for put
+parallel_log_reduce.py calculates approximate intermidiate times for put
 
 """ 
 import json
 import os
 
-def paralleL_log_reduce(logs, start_time):
+def parallel_log_reduce(logs, start_time):
     times = []
     for log in logs:
         with open(log, 'r') as f:


### PR DESCRIPTION
Previously the first sqlite connection was continuously being reused. When interacting with full manager in a flask server, I ran into the issue: `SQLite objects created in a thread can only be used in that same thread`.

I've added the `reuse_conn` option for full manager which defaults to True, but if False, it will create a new connection for any new database operation from a `put`, `get`, or `delete` call. It then discards the newly created connection.

I have not yet implemented this for `write_video_parallel` calls, and for `put_many`.

I also fixed some typos that I saw.

